### PR TITLE
Add the Lidgen Networking link inside the README.md - Fix #20

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Slowly and surely improving but probably not ready for a big game yet. Under hea
 
 ## Tech
 * C# Core
-* Lidgren Networking
+* [Lidgren Networking](https://github.com/lidgren/lidgren-network-gen3)
 * MessagePack for Serialization
 
 ## Features


### PR DESCRIPTION
Hi,

Like indicated inside the Issue #20, I have added the link inside the README.md file.
Please, review this pull request and don't hesitate to tell me some changes if needed.

- Linuxydable